### PR TITLE
fix: authenticator will panic before a new added cluster ready

### DIFF
--- a/pkg/clusters/clientprovider.go
+++ b/pkg/clusters/clientprovider.go
@@ -31,7 +31,7 @@ func (m *manager) ClientFor(name string) (*ClusterInfo, kubernetes.Interface, er
 	}
 	endpoint, err := cluster.PickOne()
 	if err != nil {
-		return nil, nil, err
+		return cluster, nil, err
 	}
 	return cluster, endpoint.Clientset(), nil
 }

--- a/pkg/clusters/clientprovider_test.go
+++ b/pkg/clusters/clientprovider_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022 ByteDance and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func createTestNotReadyClusterInfo() *ClusterInfo {
+	cfg := newTestUpstreamClusterConfig()
+	cfg.Name = "testing.notReadyCluster"
+	ret, _ := CreateClusterInfo(cfg, nil)
+	return ret
+}
+
+func Test_manager_ClientFor(t *testing.T) {
+	manager := NewManager()
+	// cluster := createTestClusterInfo()
+
+	_, _, err := manager.ClientFor("not-found")
+	if err == nil {
+		t.Error("ClientFor() want error, got nil")
+	}
+	if !errors.Is(err, ErrClusterNotFound) {
+		t.Errorf("ClientFor() want ErrClusterNotFound, got = %v", err)
+	}
+
+	// add not ready cluster
+	manager.Add(createTestNotReadyClusterInfo())
+
+	cluster, _, err := manager.ClientFor("testing.notReadyCluster")
+	if err == nil {
+		t.Error("ClientFor() want error, but got nil")
+	}
+	if cluster == nil {
+		t.Error("ClientFor() want cluster, but got nil")
+	}
+
+	// add always ready cluster
+	manager.Add(createTestClusterInfo())
+	time.Sleep(1 * time.Second)
+	cluster, client, err := manager.ClientFor("testing.cluster")
+	if err != nil {
+		t.Errorf("ClientFor() want no error, got %v", err)
+	}
+	if cluster == nil {
+		t.Error("ClientFor() want cluster, but got nil")
+	}
+	if client == nil {
+		t.Error("ClientFor() want client, but got nil")
+	}
+}

--- a/pkg/gateway/authentication/token/webhook/tokenreview.go
+++ b/pkg/gateway/authentication/token/webhook/tokenreview.go
@@ -16,7 +16,6 @@ package webhook
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -56,7 +55,7 @@ func (a *multiClusterTokenReviewAuthenticator) AuthenticateToken(ctx context.Con
 	host := info.Hostname
 
 	cluster, _, err := a.clientProvider.ClientFor(host)
-	if err != nil && errors.Is(err, clusters.ErrClusterNotFound) {
+	if err != nil {
 		return nil, false, err
 	}
 


### PR DESCRIPTION
… becomes ready

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:
fix: authenticator will panic before a new added cluster ready

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
A new added cluster has no ready endpoints before they pass health checking.
So the manager.ClientFor() returns an error for this cluster because of no ready endpoints.
But authenticator only checks if the error is `ErrClusterNotFound` and calls a method on nil pointer dereference

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
NONE

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
