### PR TITLE
fix: reset cluster featuregates when featuregate annotation is deleted

### DIFF
--- a/pkg/clusters/features/features.go
+++ b/pkg/clusters/features/features.go
@@ -54,3 +54,14 @@ var (
 func init() {
 	runtime.Must(DefaultMutableFeatureGate.Add(defaultFeatureGates))
 }
+
+func IsDefault(fg featuregate.FeatureGate) bool {
+	features := DefaultFeatureGate.KnownFeatures()
+	for _, feature := range features {
+		if fg.Enabled(featuregate.Feature(feature)) !=
+			DefaultFeatureGate.Enabled(featuregate.Feature(feature)) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
correct feature when annotation is deleted
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
