### PR TITLE
feat(metrics): add received_apiserver_request_total to record proxy r…

### DIFF
--- a/cmd/kube-gateway/app/proxy.go
+++ b/cmd/kube-gateway/app/proxy.go
@@ -126,6 +126,7 @@ func buildProxyHandlerChainFunc(clusterManager clusters.Manager, enableAccessLog
 		// handler = gatewayfilters.WithTimeoutForNonLongRunningRequests(handler, c.LongRunningFunc, c.RequestTimeout)
 		handler = genericfilters.WithWaitGroup(handler, c.LongRunningFunc, c.HandlerChainWaitGroup)
 		// new gateway handler chain
+		handler = gatewayfilters.WithPreProcessingMetrics(handler)
 		handler = gatewayfilters.WithExtraRequestInfo(handler, &request.ExtraRequestInfoFactory{})
 		handler = genericapifilters.WithRequestInfo(handler, c.RequestInfoResolver)
 		if c.SecureServing != nil && !c.SecureServing.DisableHTTP2 && c.GoawayChance > 0 {

--- a/pkg/gateway/endpoints/filters/metrics.go
+++ b/pkg/gateway/endpoints/filters/metrics.go
@@ -1,0 +1,46 @@
+// Copyright 2023 ByteDance and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filters
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kubewharf/kubegateway/pkg/gateway/endpoints/request"
+	"github.com/kubewharf/kubegateway/pkg/gateway/metrics"
+)
+
+// WithPreProcessingMetrics is a filter that record metrics before request being processed.
+func WithPreProcessingMetrics(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		info, ok := genericapirequest.RequestInfoFrom(ctx)
+		if !ok {
+			responsewriters.InternalError(w, req, fmt.Errorf("failed to get request info from context"))
+			return
+		}
+		extraInfo, ok := request.ExtraReqeustInfoFrom(ctx)
+		if !ok {
+			responsewriters.InternalError(w, req, fmt.Errorf("failed to get extra request info from context"))
+			return
+		}
+		metrics.RecordProxyRequestReceived(req, extraInfo.Hostname, info)
+
+		handler.ServeHTTP(w, req)
+	})
+}


### PR DESCRIPTION
…eceived requests

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind feature


**What this PR does / why we need it**:
add received_apiserver_request_total to record proxy received requests, it is recorded before proxy which is different from apiserver_request_total 




**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
