### PR TITLE
fix: output reverse proxy log to klog

### DIFF
--- a/pkg/gateway/proxy/dispatcher/upgradeaware.go
+++ b/pkg/gateway/proxy/dispatcher/upgradeaware.go
@@ -19,13 +19,13 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/klog"
 )
 
 // NOTICE: most of the following codes are copied from k8s.io/apimachinery/pkg/util/proxy/upgradeawarehandler.go
@@ -113,7 +113,8 @@ func (noSuppressPanicError) Write(p []byte) (n int, err error) {
 	if strings.Contains(string(p), "suppressing panic") {
 		return len(p), nil
 	}
-	return os.Stderr.Write(p)
+	klog.ErrorDepth(4, string(p))
+	return len(p), nil
 }
 
 func (h *UpgradeAwareHandler) defaultProxyTransport(url *url.URL, internalTransport http.RoundTripper) http.RoundTripper {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind bug


**What this PR does / why we need it**:
redirect reverse proxy log to klog


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

