### PR TITLE
feat(metric): record terminated metric with resource

### DIFF
--- a/cmd/kube-gateway/app/proxy.go
+++ b/cmd/kube-gateway/app/proxy.go
@@ -128,13 +128,13 @@ func buildProxyHandlerChainFunc(clusterManager clusters.Manager, enableAccessLog
 		// new gateway handler chain
 		handler = gatewayfilters.WithPreProcessingMetrics(handler)
 		handler = gatewayfilters.WithExtraRequestInfo(handler, &request.ExtraRequestInfoFactory{})
+		handler = gatewayfilters.WithTerminationMetrics(handler)
 		handler = genericapifilters.WithRequestInfo(handler, c.RequestInfoResolver)
 		if c.SecureServing != nil && !c.SecureServing.DisableHTTP2 && c.GoawayChance > 0 {
 			handler = genericfilters.WithProbabilisticGoaway(handler, c.GoawayChance)
 		}
 		handler = genericapifilters.WithCacheControl(handler)
 		handler = gatewayfilters.WithNoLoggingPanicRecovery(handler)
-		handler = gatewayfilters.WithTerminationMetrics(handler)
 		return handler
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind feature


**What this PR does / why we need it**:
1. record terminated metric with resource tag 
2. fix non resource get requests (e.g. /healthz) are recorded as list

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

