### PR TITLE
fix(metric): get proxy metric for non domain request

### DIFF
--- a/pkg/gateway/endpoints/filters/dispatcher.go
+++ b/pkg/gateway/endpoints/filters/dispatcher.go
@@ -15,11 +15,19 @@
 package filters
 
 import (
+	"net"
 	"net/http"
+
+	gatewaynet "github.com/kubewharf/kubegateway/pkg/gateway/net"
 )
 
 func WithDispatcher(handler http.Handler, dispacher http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		hostname := gatewaynet.HostWithoutPort(req.Host)
+		if ip := net.ParseIP(hostname); ip != nil {
+			handler.ServeHTTP(w, req)
+			return
+		}
 		dispacher.ServeHTTP(w, req)
 	})
 }

--- a/pkg/gateway/proxy/server.go
+++ b/pkg/gateway/proxy/server.go
@@ -16,6 +16,8 @@ package server
 
 import (
 	apiserver "github.com/kubewharf/apiserver-runtime/pkg/server"
+	metricsregistry "github.com/kubewharf/kubegateway/pkg/gateway/metrics/registry"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/kubernetes/pkg/master"
@@ -58,6 +60,8 @@ func (c *CompletedConfig) New(delegationTarget genericapiserver.DelegationTarget
 	if err != nil {
 		return nil, err
 	}
+
+	s.Handler.NonGoRestfulMux.Handle("/metrics", promhttp.HandlerFor(metricsregistry.DefaultGatherer, promhttp.HandlerOpts{}))
 
 	if c.ExtraConfig.UpstreamClusterController != nil {
 		// start upstream controller


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

get proxy metric for non domain request

**What this PR does / why we need it**:

kubegateway returns "not being proxied" error when access /metrics api from proxy port

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubewharf/kubegateway/issues/39

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
