### PR TITLE
fix: trigger upstream health check immediately when start

### DIFF
--- a/pkg/clusters/endpoint.go
+++ b/pkg/clusters/endpoint.go
@@ -154,6 +154,8 @@ func startGatewayHealthCheck(e *EndpointInfo, interval time.Duration, ctx contex
 		tick := time.NewTicker(interval)
 		defer tick.Stop()
 
+		// trigger health check immediately
+		e.healthCheckCh <- struct{}{}
 		for {
 			select {
 			case <-tick.C:


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:

trigger upstream health check immediately when start

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubewharf/kubegateway/issues/44

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
