### PR TITLE
fix: client state lock for global maxinflight

### DIFF
--- a/pkg/ratelimiter/store/flowcontrol/global_flowcontrol.go
+++ b/pkg/ratelimiter/store/flowcontrol/global_flowcontrol.go
@@ -12,7 +12,7 @@ var (
 
 type GlobalFlowControl interface {
 	TryAcquireN(instance string, token int32) bool
-	SetState(instance string, requestId int64, current int32) (int32, error)
+	SetState(instance string, requestId int64, current int32) (accept bool, latest int32, err error)
 	String() string
 	Resize(n int32, burst int32) bool
 	Type() proxyv1alpha1.FlowControlSchemaType

--- a/pkg/ratelimiter/store/flowcontrol/global_flowcontrol.go
+++ b/pkg/ratelimiter/store/flowcontrol/global_flowcontrol.go
@@ -16,6 +16,7 @@ type GlobalFlowControl interface {
 	String() string
 	Resize(n int32, burst int32) bool
 	Type() proxyv1alpha1.FlowControlSchemaType
+	DebugInfo() string
 }
 
 func NewGlobalFlowControl(schema proxyv1alpha1.FlowControlSchema) GlobalFlowControl {

--- a/pkg/ratelimiter/store/flowcontrol/tokenbucket.go
+++ b/pkg/ratelimiter/store/flowcontrol/tokenbucket.go
@@ -53,6 +53,10 @@ func (f *globalTokenBucket) Resize(n int32, burst int32) bool {
 	return resized
 }
 
-func (f *globalTokenBucket) SetState(instance string, requestId int64, current int32) (int32, error) {
-	return -1, nil
+func (f *globalTokenBucket) SetState(instance string, requestId int64, current int32) (bool, int32, error) {
+	return false, -1, nil
+}
+
+func (f *globalTokenBucket) DebugInfo() string {
+	return ""
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

fix ratelimiter state inconsistency after client instance were deleted

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
