### PR TITLE
feat: add metrics by user

### DIFF
--- a/cmd/kube-gateway/app/proxy.go
+++ b/cmd/kube-gateway/app/proxy.go
@@ -157,7 +157,7 @@ func buildProxyHandlerChainFunc(o *proxyHandlerOptions) func(apiHandler http.Han
 		// rate and throughput monitor
 		throughputMonitor := monitor.NewThroughputMonitor()
 		rateMonitor := monitor.NewRateMonitor()
-		handler = gatewayfilters.WithRequestThroughput(handler, throughputMonitor)
+		handler = gatewayfilters.WithRequestReaderWriterWrapper(handler, throughputMonitor)
 		handler = gatewayfilters.WithRequestRate(handler, c.LongRunningFunc, rateMonitor)
 
 		handler = gatewayfilters.WithPreProcessingMetrics(handler)

--- a/cmd/kube-gateway/app/proxy.go
+++ b/cmd/kube-gateway/app/proxy.go
@@ -163,7 +163,7 @@ func buildProxyHandlerChainFunc(o *proxyHandlerOptions) func(apiHandler http.Han
 		handler = gatewayfilters.WithPreProcessingMetrics(handler)
 		handler = gatewayfilters.WithTraceLog(handler, o.enableProxyTracing, c.LongRunningFunc)
 		handler = gatewayfilters.WithUpstreamInfo(handler, o.clusterManager, c.Serializer)
-		handler = gatewayfilters.WithExtraRequestInfo(handler, &request.ExtraRequestInfoFactory{}, c.Serializer)
+		handler = gatewayfilters.WithExtraRequestInfo(handler, &request.ExtraRequestInfoFactory{LongRunningFunc: c.LongRunningFunc}, c.Serializer)
 		handler = gatewayfilters.WithTerminationMetrics(handler)
 		handler = gatewayfilters.WithRequestInfo(handler, c.RequestInfoResolver)
 		if c.SecureServing != nil && !c.SecureServing.DisableHTTP2 && o.goawayChance > 0 {

--- a/pkg/gateway/endpoints/filters/termination.go
+++ b/pkg/gateway/endpoints/filters/termination.go
@@ -82,6 +82,7 @@ func (rw *terminationMetricsWriter) recordMetrics(req *http.Request) {
 			// use status text when reason is empty
 			reason = stringy.New(http.StatusText(rw.status)).SnakeCase().ToLower()
 		}
-		metrics.RecordProxyRequestTermination(req, rw.status, reason, proxyInfo.FlowControl)
+
+		metrics.RecordProxyRequestTermination(req, rw.status, reason, proxyInfo.FlowControl, proxyInfo.User)
 	}
 }

--- a/pkg/gateway/endpoints/request/proxyInfo.go
+++ b/pkg/gateway/endpoints/request/proxyInfo.go
@@ -17,6 +17,8 @@ package request
 import (
 	"context"
 	"fmt"
+
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 // ProxyInfo contains information that indicates if the request is proxied
@@ -25,6 +27,7 @@ type ProxyInfo struct {
 	Endpoint    string
 	Reason      string
 	FlowControl string
+	User        user.Info
 }
 
 func NewProxyInfo() *ProxyInfo {
@@ -44,12 +47,13 @@ func ExtraProxyInfoFrom(ctx context.Context) (*ProxyInfo, bool) {
 	return info, ok
 }
 
-func SetFlowControl(ctx context.Context, flowControl string) error {
+func SetProxyInfo(ctx context.Context, flowControl string, user user.Info) error {
 	info, ok := ExtraProxyInfoFrom(ctx)
 	if !ok {
 		return fmt.Errorf("no proxy info found in context")
 	}
 	info.FlowControl = flowControl
+	info.User = user
 	return nil
 }
 

--- a/pkg/gateway/endpoints/request/readerwriter.go
+++ b/pkg/gateway/endpoints/request/readerwriter.go
@@ -1,0 +1,8 @@
+package request
+
+type RequestReaderWriterWrapper interface {
+	RequestSize() int
+	ResponseSize() int
+	Status() int
+	AddedInfo() string
+}

--- a/pkg/gateway/endpoints/request/requestinfo.go
+++ b/pkg/gateway/endpoints/request/requestinfo.go
@@ -71,6 +71,7 @@ type ExtraRequestInfo struct {
 	IsImpersonateRequest bool
 	Impersonator         user.Info
 	UpstreamCluster      *clusters.ClusterInfo
+	ReaderWriter         RequestReaderWriterWrapper
 	IsProxyRequest       bool
 	IsLongRunningRequest bool
 }

--- a/pkg/gateway/endpoints/request/requestinfo.go
+++ b/pkg/gateway/endpoints/request/requestinfo.go
@@ -16,10 +16,12 @@ package request
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/kubewharf/kubegateway/pkg/clusters"
 	"github.com/kubewharf/kubegateway/pkg/gateway/net"
@@ -39,9 +41,19 @@ type ExtraRequestInfoResolver interface {
 	NewExtraRequestInfo(req *http.Request) (*ExtraRequestInfo, error)
 }
 
-type ExtraRequestInfoFactory struct{}
+type ExtraRequestInfoFactory struct {
+	LongRunningFunc apirequest.LongRunningRequestCheck
+}
 
 func (f *ExtraRequestInfoFactory) NewExtraRequestInfo(req *http.Request) (*ExtraRequestInfo, error) {
+	ctx := req.Context()
+	requestInfo, ok := apirequest.RequestInfoFrom(ctx)
+	if !ok {
+		return nil, errors.New("no RequestInfo found in the context")
+	}
+
+	isLongRunning := f.LongRunningFunc(req, requestInfo)
+
 	isImpersonate := len(req.Header.Get(authenticationv1.ImpersonateUserHeader)) > 0
 	hostname := net.HostWithoutPort(req.Host)
 
@@ -49,6 +61,7 @@ func (f *ExtraRequestInfoFactory) NewExtraRequestInfo(req *http.Request) (*Extra
 		Scheme:               req.URL.Scheme,
 		Hostname:             hostname,
 		IsImpersonateRequest: isImpersonate,
+		IsLongRunningRequest: isLongRunning,
 	}, nil
 }
 
@@ -59,6 +72,7 @@ type ExtraRequestInfo struct {
 	Impersonator         user.Info
 	UpstreamCluster      *clusters.ClusterInfo
 	IsProxyRequest       bool
+	IsLongRunningRequest bool
 }
 
 // WithExtraRequestInfo returns a copy of parent in which the ExtraRequestInfo value is set

--- a/pkg/gateway/metrics/metrics.go
+++ b/pkg/gateway/metrics/metrics.go
@@ -303,14 +303,19 @@ func RecordRequestThroughput(requestSizeTotal, responseSizeTotal int64) {
 	})
 }
 
-func RecordProxyTraceLatency(traceLatencies map[string]time.Duration, serverName string, requestInfo *request.RequestInfo) {
+func RecordProxyTraceLatency(traceLatencies map[string]time.Duration, serverName string, requestInfo *request.RequestInfo, user user.Info, req *http.Request) {
 	verb := strings.ToUpper(requestInfo.Verb)
 	resource := cleanResource(requestInfo)
+	userName := cleanUserForMetric(user)
+
 	metric := MetricInfo{
 		ServerName:     serverName,
 		Verb:           verb,
 		Resource:       resource,
 		TraceLatencies: traceLatencies,
+		Request:        req,
+		User:           user,
+		UserName:       userName,
 	}
 	ProxyHandlingLatencyObservers.Observe(metric)
 }

--- a/pkg/gateway/metrics/metrics.go
+++ b/pkg/gateway/metrics/metrics.go
@@ -94,7 +94,9 @@ func MonitorProxyRequest(req *http.Request, serverName, endpoint, flowControl st
 	user user.Info,
 	isLongRunning bool,
 	contentType string,
-	httpCode, respSize int,
+	httpCode,
+	reqSize,
+	respSize int,
 	elapsed time.Duration) {
 	if requestInfo == nil {
 		requestInfo = &request.RequestInfo{Verb: req.Method, Path: req.URL.Path}
@@ -120,6 +122,7 @@ func MonitorProxyRequest(req *http.Request, serverName, endpoint, flowControl st
 		Verb:          verb,
 		Resource:      resource,
 		ResponseSize:  int64(respSize),
+		RequestSize:   int64(reqSize),
 		HttpCode:      codeToString(httpCode),
 		Latency:       elapsedSeconds,
 		Request:       req,
@@ -135,6 +138,8 @@ func MonitorProxyRequest(req *http.Request, serverName, endpoint, flowControl st
 	if requestInfo.IsResourceRequest {
 		ProxyResponseSizesObservers.Observe(metricInfo)
 	}
+
+	ProxyRequestDataSizeObservers.Observe(metricInfo)
 }
 
 // RecordProxyRequestTermination records that the request was terminated early as part of a resource
@@ -288,7 +293,7 @@ func RecordProxyRateAndInflight(rate float64, inflight int32) {
 }
 
 func RecordRequestThroughput(requestSizeTotal, responseSizeTotal int64) {
-	ProxyRequestThroughputObservers.Observe(MetricInfo{
+	ProxyRequestTotalDataSizeObservers.Observe(MetricInfo{
 		RequestSize:  requestSizeTotal,
 		ResponseSize: responseSizeTotal,
 	})

--- a/pkg/gateway/metrics/obsever.go
+++ b/pkg/gateway/metrics/obsever.go
@@ -3,6 +3,9 @@ package metrics
 import (
 	"net/http"
 	"time"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 type MetricObserver interface {
@@ -35,6 +38,10 @@ var (
 
 type MetricInfo struct {
 	Request           *http.Request
+	RequestInfo       *request.RequestInfo
+	User              user.Info
+	UserName          string
+	IsLongRunning     bool
 	IsResourceRequest bool
 	ServerName        string
 	Endpoint          string

--- a/pkg/gateway/metrics/obsever.go
+++ b/pkg/gateway/metrics/obsever.go
@@ -30,8 +30,9 @@ var (
 	ProxyRateLimiterRequestCounterObservers = newUnionObserver()
 	ProxyGlobalFlowControlAcquireObservers  = newUnionObserver()
 
-	ProxyRequestInflightObservers   = newUnionObserver()
-	ProxyRequestThroughputObservers = newUnionObserver()
+	ProxyRequestInflightObservers      = newUnionObserver()
+	ProxyRequestTotalDataSizeObservers = newUnionObserver()
+	ProxyRequestDataSizeObservers      = newUnionObserver()
 
 	ProxyHandlingLatencyObservers = newUnionObserver()
 )

--- a/pkg/gateway/proxy/dispatcher/dispatcher.go
+++ b/pkg/gateway/proxy/dispatcher/dispatcher.go
@@ -86,7 +86,7 @@ func (d *dispatcher) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	_ = request.SetFlowControl(req.Context(), endpointPicker.FlowControlName())
+	_ = request.SetProxyInfo(req.Context(), endpointPicker.FlowControlName(), user)
 
 	flowcontrol := endpointPicker.FlowControl()
 	if !flowcontrol.TryAcquire() {

--- a/pkg/gateway/proxy/dispatcher/dispatcher.go
+++ b/pkg/gateway/proxy/dispatcher/dispatcher.go
@@ -144,7 +144,7 @@ func (d *dispatcher) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}()
 
 	logging := d.enableAccessLog && endpointPicker.EnableLog()
-	delegate := decorateResponseWriter(req, w, logging, requestInfo, extraInfo.Hostname, endpoint.Endpoint, user, extraInfo.Impersonator, endpointPicker.FlowControlName())
+	delegate := decorateResponseWriter(req, w, logging, requestInfo, extraInfo, endpoint.Endpoint, user, extraInfo.Impersonator, endpointPicker.FlowControlName())
 	delegate.MonitorBeforeProxy()
 	defer delegate.MonitorAfterProxy()
 

--- a/pkg/gateway/proxy/dispatcher/dispatcher.go
+++ b/pkg/gateway/proxy/dispatcher/dispatcher.go
@@ -26,7 +26,6 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/endpoints/filters"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/endpoints/responsewriter"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/kubewharf/kubegateway/pkg/clusters"
@@ -144,15 +143,14 @@ func (d *dispatcher) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}()
 
 	logging := d.enableAccessLog && endpointPicker.EnableLog()
-	delegate := decorateResponseWriter(req, w, logging, requestInfo, extraInfo, endpoint.Endpoint, user, extraInfo.Impersonator, endpointPicker.FlowControlName())
-	delegate.MonitorBeforeProxy()
-	defer delegate.MonitorAfterProxy()
+	monitor := requestMonitor(req, w, logging, requestInfo, extraInfo, endpoint.Endpoint, user, extraInfo.Impersonator, endpointPicker.FlowControlName())
+	monitor.MonitorBeforeProxy()
+	defer monitor.MonitorAfterProxy()
 
-	rw := responsewriter.WrapForHTTP1Or2(delegate)
-	responder := newErrorResponder(d.codecs, endpoint, requestInfo, delegate)
+	responder := newErrorResponder(d.codecs, endpoint, requestInfo, extraInfo.ReaderWriter)
 
 	proxyHandler := NewUpgradeAwareHandler(location, endpoint.ProxyTransport, endpoint.PorxyUpgradeTransport, false, false, responder)
-	proxyHandler.ServeHTTP(rw, newReq)
+	proxyHandler.ServeHTTP(w, newReq)
 }
 
 func (d *dispatcher) responseError(err *errors.StatusError, w http.ResponseWriter, req *http.Request, reason string) {

--- a/pkg/util/tracing/trace.go
+++ b/pkg/util/tracing/trace.go
@@ -31,11 +31,12 @@ const (
 )
 
 const (
-	MetricStageClientRead    = "client_read"
-	MetricStageClientWrite   = "client_write"
-	MetricStageUpstreamRead  = "upstream_read"
-	MetricStageUpstreamWrite = "upstream_write"
-	MetricStageHandlingDelay = "handling_delay"
+	MetricStageClientRead     = "client_read"
+	MetricStageClientWrite    = "client_write"
+	MetricStageUpstreamRead   = "upstream_read"
+	MetricStageUpstreamWrite  = "upstream_write"
+	MetricStageHandlingDelay  = "handling_delay"
+	MetricStageClientOverCost = "client_over_cost"
 )
 
 var (
@@ -181,6 +182,8 @@ func (t *RequestTraceInfo) StageLatency() map[string]time.Duration {
 		}
 	}
 	stageLatency[MetricStageHandlingDelay] = t.endTime.Sub(t.startTime) - eliminatedLatency
+	stageLatency[MetricStageClientOverCost] = stageLatency[MetricStageClientRead] + stageLatency[MetricStageClientWrite] -
+		stageLatency[MetricStageUpstreamRead] - stageLatency[MetricStageUpstreamWrite]
 
 	t.stageLatency = stageLatency
 	return stageLatency


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind feature


**What this PR does / why we need it**:

This PR adds a user metric feature to the KubeGateway project. It collects and presents user - related metrics, including the number of requests per user, average request latency per user, and the success rate of requests per user. These metrics are essential for understanding user behavior, identifying performance bottlenecks, and performing capacity planning.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubewharf/kubegateway/issues/72


**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
