### PR TITLE
feat: support user suffix in dispatch rule

### DIFF
--- a/pkg/apis/proxy/v1alpha1/evaluation_helpers.go
+++ b/pkg/apis/proxy/v1alpha1/evaluation_helpers.go
@@ -71,7 +71,12 @@ func UserOrServiceAccountMatches(users []string, serviceAccounts []ServiceAccoun
 		return true
 	}
 
-	if simpleMatches(users, []string{requestUser}) {
+	if simpleMatches(users, []string{requestUser}, func(m matcher) bool {
+		if strings.HasSuffix(m.value, "*") && strings.HasPrefix(requestUser, strings.TrimRight(m.value, "*")) {
+			return true
+		}
+		return false
+	}) {
 		return true
 	}
 

--- a/pkg/apis/proxy/v1alpha1/evaluation_helpers_test.go
+++ b/pkg/apis/proxy/v1alpha1/evaluation_helpers_test.go
@@ -268,6 +268,15 @@ func TestUserOrServiceAccountMatches(t *testing.T) {
 			true,
 		},
 		{
+			"match user suffix",
+			args{
+				[]string{"user-*"},
+				nil,
+				"user-test1",
+			},
+			true,
+		},
+		{
 			"match service account",
 			args{
 				[]string{},


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature


**What this PR does / why we need it**:

to support suffix matching for dispatch rule like "system:node:*"


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
