### PR TITLE
fix: reset transport when detect health check hang

### DIFF
--- a/pkg/clusters/endpoint_test.go
+++ b/pkg/clusters/endpoint_test.go
@@ -21,13 +21,13 @@ import (
 func TestEndpointInfo_ReadyAndReason(t *testing.T) {
 	tests := []struct {
 		name      string
-		status    endpointStatus
+		status    *endpointStatus
 		wantReady bool
 		want      string
 	}{
 		{
 			"ready",
-			endpointStatus{
+			&endpointStatus{
 				Disabled: false,
 				Healthy:  true,
 			},
@@ -36,7 +36,7 @@ func TestEndpointInfo_ReadyAndReason(t *testing.T) {
 		},
 		{
 			"disabled",
-			endpointStatus{
+			&endpointStatus{
 				Disabled: true,
 				Healthy:  true,
 			},
@@ -45,7 +45,7 @@ func TestEndpointInfo_ReadyAndReason(t *testing.T) {
 		},
 		{
 			"unhealthy",
-			endpointStatus{
+			&endpointStatus{
 				Disabled: false,
 				Healthy:  false,
 				Reason:   "Timeout",

--- a/pkg/clusters/endpoint_test.go
+++ b/pkg/clusters/endpoint_test.go
@@ -71,3 +71,34 @@ func TestEndpointInfo_ReadyAndReason(t *testing.T) {
 		})
 	}
 }
+
+func TestEndpointInfo_UnhealthyCount(t *testing.T) {
+	e := &EndpointInfo{
+		Endpoint: "",
+		status: &endpointStatus{
+			Disabled: true,
+			Healthy:  true,
+		},
+	}
+	if e.GetUnhealthyCount() != 0 {
+		t.Errorf("unhealthy count should be 0, actual: %d", e.GetUnhealthyCount())
+	}
+
+	for i := 0; i < 2; i++ {
+		e.UpdateStatus(false, "mock error", "mock error message")
+		if e.GetUnhealthyCount() != i+1 {
+			t.Errorf("unhealthy count should be %d, actual: %d", i+1, e.GetUnhealthyCount())
+		}
+	}
+	e.UpdateStatus(true, "", "")
+	if e.GetUnhealthyCount() != 0 {
+		t.Errorf("unhealthy count should be 0, actual: %d", e.GetUnhealthyCount())
+	}
+
+	for i := 0; i < 5; i++ {
+		e.UpdateStatus(false, "mock error", "mock error message")
+		if e.GetUnhealthyCount() != i+1 {
+			t.Errorf("unhealthy count should be %d, actual: %d", i+1, e.GetUnhealthyCount())
+		}
+	}
+}

--- a/pkg/gateway/controllers/upstream_controller.go
+++ b/pkg/gateway/controllers/upstream_controller.go
@@ -361,7 +361,10 @@ func GatewayHealthCheck(e *clusters.EndpointInfo) (done bool) {
 	klog.Errorf("upstream health check failed, cluster=%q endpoint=%q reason=%q message=%q", e.Cluster, e.Endpoint, reason, message)
 	e.UpdateStatus(false, reason, message)
 
-	if err != nil && strings.Contains(err.Error(), "Client.Timeout or context cancellation while reading body") {
+	const ResetTransportThreshold = 3
+	if err != nil &&
+		strings.Contains(err.Error(), "Client.Timeout or context cancellation while reading body") &&
+		e.GetUnhealthyCount() >= ResetTransportThreshold {
 		klog.Warningf("transport to endpoint %s hang", e.Endpoint)
 		if err := e.ResetTransport(); err != nil {
 			klog.Warningf("reset transport to endpoint %s error: %v", e.Endpoint, err)

--- a/pkg/gateway/controllers/upstream_controller.go
+++ b/pkg/gateway/controllers/upstream_controller.go
@@ -360,5 +360,13 @@ func GatewayHealthCheck(e *clusters.EndpointInfo) (done bool) {
 	}
 	klog.Errorf("upstream health check failed, cluster=%q endpoint=%q reason=%q message=%q", e.Cluster, e.Endpoint, reason, message)
 	e.UpdateStatus(false, reason, message)
+
+	if err != nil && strings.Contains(err.Error(), "Client.Timeout or context cancellation while reading body") {
+		klog.Warningf("transport to endpoint %s hang", e.Endpoint)
+		if err := e.ResetTransport(); err != nil {
+			klog.Warningf("reset transport to endpoint %s error: %v", e.Endpoint, err)
+		}
+	}
+
 	return done
 }

--- a/pkg/transport/cancelable_transport.go
+++ b/pkg/transport/cancelable_transport.go
@@ -1,0 +1,37 @@
+package transport
+
+import (
+	"context"
+	"net/http"
+)
+
+type CancelableTransport struct {
+	inner  http.RoundTripper
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (ts *CancelableTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	reqCtx := r.Context()
+	ctx, cancel := context.WithCancel(reqCtx)
+	go func() {
+		select {
+		case <-reqCtx.Done(): // req ctx is done
+		case <-ts.ctx.Done(): // transport is done
+			cancel()
+		}
+	}()
+	r2 := r.Clone(ctx)
+	return ts.inner.RoundTrip(r2)
+}
+func (ts *CancelableTransport) Close() {
+	ts.cancel()
+}
+func NewCancelableTransport(inner http.RoundTripper) *CancelableTransport {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &CancelableTransport{
+		inner:  inner,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}

--- a/pkg/transport/cancelable_transport_test.go
+++ b/pkg/transport/cancelable_transport_test.go
@@ -1,0 +1,75 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCancelableTransportClose(t *testing.T) {
+	ts := httptest.NewServer(new(testServer))
+	defer ts.Close()
+	ct := NewCancelableTransport(http.DefaultTransport)
+	client := http.Client{
+		Transport: ct,
+	}
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Errorf("get error: %v", err)
+	}
+	resp.Body.Close()
+	time.AfterFunc(200*time.Millisecond, func() {
+		ct.Close()
+	})
+	start := time.Now()
+	_, err = client.Get(ts.URL)
+	latency := time.Since(start)
+	if err == nil {
+		t.Errorf("should have error")
+	}
+	if latency > 300*time.Millisecond {
+		t.Errorf("should cancel request")
+	}
+}
+
+func TestCancelableTransportCancel(t *testing.T) {
+	ct := NewCancelableTransport(new(mockTransport))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", "localhost", nil)
+	if err != nil {
+		t.Errorf("new request error")
+	}
+	_, err = ct.RoundTrip(req)
+	if err == nil {
+		t.Errorf("should have error")
+	}
+	if err.Error() != "req context done" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+type mockTransport struct {
+}
+
+// RoundTrip implements http.RoundTripper.
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("req context done")
+	default:
+	}
+	return nil, fmt.Errorf("mock error")
+}
+
+type testServer struct {
+}
+
+func (s *testServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	time.Sleep(500 * time.Millisecond)
+	w.WriteHeader(200)
+}


### PR DESCRIPTION
**What type of PR is this?**


> /kind bug

**What this PR does / why we need it**:
in some casaes, transport hang forever, so we add a checker to reset transport when detect health check hang

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
